### PR TITLE
Explicitly enable private GAR repos

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,3 +18,19 @@ This authenticates to Google Cloud and then Google Artifact Registry.
           # REQUIRED if you want private GAR PyPI access
           enable_private_pypi: true
 ```
+
+# Other important information
+
+Enabling the private PyPI repo involves installing a Python package. This will be installed via `pip`.
+
+Users of this action should **pre-configure the runner** as appropriate prior to calling this.
+
+Likely that means calling e.g., [actions/setup-python to set the correct default Python version](https://github.com/actions/setup-python)
+
+
+```yaml
+      - uses: actions/setup-python@v5
+        with:
+          # auto-detect Python version from file; alternatively you can set to explicit version if desired
+          python-version-file: pyproject.toml
+```

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@ This authenticates to Google Cloud and then Google Artifact Registry.
 
 * Auth to Google Cloud (getting an access token)
 * Auth to Google Artifact Registry (`us-docker.pkg.dev`)
+* Enable PyPI on Google Artifact Registry
 
 # How to use it
 
@@ -12,4 +13,8 @@ This authenticates to Google Cloud and then Google Artifact Registry.
         uses: 'uwit-iam/action-auth-artifact-registry@main'
         with:
           credentials: "${{ secrets.MCI_GCLOUD_AUTH_JSON }}"
+          # REQUIRED if you want private GAR container registry access
+          enable_private_docker: true
+          # REQUIRED if you want private GAR PyPI access
+          enable_private_pypi: true
 ```

--- a/action.yaml
+++ b/action.yaml
@@ -30,7 +30,7 @@ runs:
         token_format: 'access_token'
 
     - name: Auth to Google Artifact Registry
-      if ${{ inputs.enable_private_docker }}
+      if: ${{ inputs.enable_private_docker }}
       shell: bash
       # https://github.com/google-github-actions/auth#authenticating-to-container-registry-and-artifact-registry
       # requires role: roles/iam.serviceAccountTokenCreator

--- a/action.yaml
+++ b/action.yaml
@@ -32,6 +32,7 @@ runs:
 
     - name: Setup IAM PyPI
       if: ${{ inputs.enable_iam_pypi }}
+      shell: bash
       run: |
           # install keyring so pip can talk to GAR PyPI
           pip install keyrings.google-artifactregistry-auth

--- a/action.yaml
+++ b/action.yaml
@@ -6,8 +6,14 @@ inputs:
     type: string
     required: true
 
-  enable_iam_pypi:
-    description: Should the environment be updated to work with IAM's PyPI on GAR?
+  enable_private_docker:
+    description: Should the environment be updated to enable private GAR-based Docker?
+    type: boolean
+    required: false
+    default: false
+
+  enable_private_pypi:
+    description: Should the environment be updated to enable private GAR-based PyPI?
     type: boolean
     required: false
     default: false
@@ -24,6 +30,7 @@ runs:
         token_format: 'access_token'
 
     - name: Auth to Google Artifact Registry
+      if ${{ inputs.enable_private_docker }}
       shell: bash
       # https://github.com/google-github-actions/auth#authenticating-to-container-registry-and-artifact-registry
       # requires role: roles/iam.serviceAccountTokenCreator
@@ -31,7 +38,7 @@ runs:
         echo '${{ steps.auth.outputs.access_token }}' | docker login -u oauth2accesstoken --password-stdin https://us-docker.pkg.dev
 
     - name: Setup IAM PyPI
-      if: ${{ inputs.enable_iam_pypi }}
+      if: ${{ inputs.enable_private_pypi }}
       shell: bash
       run: |
           # install keyring so pip can talk to GAR PyPI

--- a/action.yaml
+++ b/action.yaml
@@ -6,6 +6,12 @@ inputs:
     type: string
     required: true
 
+  enable_iam_pypi:
+    description: Should the environment be updated to work with IAM's PyPI on GAR?
+    type: boolean
+    required: false
+    default: false
+
 runs:
   using: "composite"
   steps:
@@ -23,3 +29,9 @@ runs:
       # requires role: roles/iam.serviceAccountTokenCreator
       run: |-
         echo '${{ steps.auth.outputs.access_token }}' | docker login -u oauth2accesstoken --password-stdin https://us-docker.pkg.dev
+
+    - name: Setup IAM PyPI
+      if: ${{ inputs.enable_iam_pypi }}
+      run: |
+          # install keyring so pip can talk to GAR PyPI
+          pip install keyrings.google-artifactregistry-auth


### PR DESCRIPTION
This adds support for IAM's private PyPI

In addition it changes existing support for IAM's private container registry to only work when explicitly enabled.