### PR TITLE
Provide auth outputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ This authenticates to Google Cloud and then Google Artifact Registry.
 These outputs are all provided by the underling [google-github-actions/auth action's outputs](https://github.com/google-github-actions/auth?tab=readme-ov-file#outputs)
 
 * `project_id`: Provided or extracted value for the Google Cloud project ID.
-* `credentials_file_path`: Path on the local filesystem where the generated credentials file resides. Provided by Google auth action.
+* `credentials_file_path`: Path on the local filesystem where the generated credentials file resides.
 * `auth_token`: The Google Cloud federated token (for Workload Identity Federation) or self-signed JWT (for a Service Account Key JSON).
 * `access_token`: The Google Cloud access token for calling other Google Cloud APIs.
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,10 @@ This authenticates to Google Cloud and then Google Artifact Registry.
 
 * Auth to Google Cloud (getting an access token)
 * Auth to Google Artifact Registry (`us-docker.pkg.dev`)
-* Enable PyPI on Google Artifact Registry
+* Enable PyPI on Google Artifact Registry by installing an appropriate keyring via `pip`
+    * This **does not integrate with poetry** if you are using `pipx`. For that you can
+        * Manually run ` poetry self add keyrings.google-artifactregistry-auth`
+        * PR an extra input to this action (or ask @miker985 to do it)
 
 # How to use it
 
@@ -18,6 +21,15 @@ This authenticates to Google Cloud and then Google Artifact Registry.
           # REQUIRED if you want private GAR PyPI access
           enable_private_pypi: true
 ```
+
+# Outputs
+
+These outputs are all provided by the underling [google-github-actions/auth action's outputs](https://github.com/google-github-actions/auth?tab=readme-ov-file#outputs)
+
+* `project_id`: Provided or extracted value for the Google Cloud project ID.
+* `credentials_file_path`: Path on the local filesystem where the generated credentials file resides. Provided by Google auth action.
+* `auth_token`: The Google Cloud federated token (for Workload Identity Federation) or self-signed JWT (for a Service Account Key JSON).
+* `access_token`: The Google Cloud access token for calling other Google Cloud APIs.
 
 # Other important information
 

--- a/action.yaml
+++ b/action.yaml
@@ -23,7 +23,7 @@ outputs:
     description: Provided or extracted value for the Google Cloud project ID.
     value: ${{ steps.auth.outputs.project_id }}
   credentials_file_path:
-    description: Path on the local filesystem where the generated credentials file resides. Provided by Google auth action.
+    description: Path on the local filesystem where the generated credentials file resides.
     value: ${{ steps.auth.outputs.credentials_file_path }}
   auth_token:
     description: The Google Cloud federated token (for Workload Identity Federation) or self-signed JWT (for a Service Account Key JSON).


### PR DESCRIPTION
Update the action to provide relevant outputs from `google-github-actions/auth`

Of note, the `credentials_file_path` output is useful to pass as a "secret file" to docker during build. You can see it's use [in this related PR](https://github.com/UWIT-IAM/netid_arrest/pull/6/files)  in the `docker/build-push-action` action

Note that I already merged the ~code~ YAML bit of this, this is just the documentation update